### PR TITLE
Fix some errors running on OSX 10.9 with Homebrew toolchain

### DIFF
--- a/src/ocrPage.sh
+++ b/src/ocrPage.sh
@@ -58,7 +58,7 @@ getImgInfo() {
 	
 	
 	# check if the page already contains fonts (which should not be the case for PDF based on scanned files
-	[ `pdffonts -f $page -l $page ${FILE_INPUT_PDF} | wc -l` -gt 2 ] && echo "Page $page: Page already contains font data !!!" && return 1
+	[ `pdffonts -f $page -l $page "${FILE_INPUT_PDF}" | wc -l` -gt 2 ] && echo "Page $page: Page already contains font data !!!" && return 1
 
 	
 	# extract raw image from pdf file to compute resolution


### PR DESCRIPTION
First off, thank you for pulling together a coherent and useful toolchain for command OCR. I've spent too much time looking for this.

These changes probably depend more on the version of bash/sh being used.
