### PR TITLE
Fix AttributeError on self.width if Tesseract finds no OCR text

### DIFF
--- a/src/hocrTransform.py
+++ b/src/hocrTransform.py
@@ -115,6 +115,7 @@ class hocrTransform():
 			self.xmlns = matches.group(1)
 
 		# get dimension in pt (not pixel!!!!) of the OCRed image
+		self.width, self.height = None, None
 		for div in self.hocr.findall(".//%sdiv[@class='ocr_page']"%(self.xmlns)):
 			coords = self.element_coordinates(div)
 			self.width = self.px2pt(coords[2]-coords[0])


### PR DESCRIPTION
self.width remains undefined unless hOCR finds text. If there is <div class="ocr_page"> tag, which happens on occasion for some reason, then the Python script exits with an AttributeError instead of an error message, as apparently intended.

Error message is:
AttributeError: ‘hocrTransform’ object has no attribute ‘width’
