### PR TITLE
Fix temporary folder name generation collisions

### DIFF
--- a/OCRmyPDF.sh
+++ b/OCRmyPDF.sh
@@ -204,19 +204,16 @@ fi
 
 # Initialize path to temporary files
 today=$(date +"%Y%m%d_%H%M")
-fld=$(basename "$FILE_INPUT_PDF" | sed 's/[.][^.]*//')
-TMP_FLD="${TMP}/$today.filename.$fld"
+fld=$(basename "$FILE_INPUT_PDF" | sed 's/[.][^.]*$//')
+prefix="${today}.filename.${fld}"
+TMP_FLD=`TMPDIR=${TMP} mktemp -d -t "${prefix}"`
 FILE_TMP="${TMP_FLD}/tmp.txt"						# temporary file with a very short lifetime (may be used for several things)
 FILE_PAGES_INFO="${TMP_FLD}/pages-info.txt"				# for each page: page #; width in pt; height in pt
 FILE_OUTPUT_PDF_CAT="${TMP_FLD}/ocred.pdf"				# concatenated OCRed PDF files
 FILE_VALIDATION_LOG="${TMP_FLD}/pdf_validation.log"			# log file containing the results of the validation of the PDF/A file
 
 # Create tmp folder
-[ $VERBOSITY -ge $LOG_DEBUG ] && echo "Creating temporary folder: \"$TMP_FLD\""
-rm -r -f "${TMP_FLD}"
-mkdir -p "${TMP_FLD}"
-
-
+[ $VERBOSITY -ge $LOG_DEBUG ] && echo "Created temporary folder: \"$TMP_FLD\""
 
 
 # get the size of each pdf page (width / height) in pt (inch*72)


### PR DESCRIPTION
First, the regular expression matches everything after the first period
in a filename.  Adding the $ make it match the last, so that filenames
such as “Report.1.pdf” get trimmed to “Report.1”.

Next use mktemp to get the OS to create a temporary folder.  It will
guarantee a unique directory name beginning with prefix, even if parallel
processes are at work. (mktemp creates the folder and returns its name
as an atomic operation, making the rm -rf/mkdir pair unnecessary.) This
should avoid most tmp folder errors, including a duplicate "$today" string
and duplicate filenames in the same folder tree on a parallel run.
