### PR TITLE
small changes to make this work on Ubuntu 12.04 called via symlink

### DIFF
--- a/OCRmyPDF.sh
+++ b/OCRmyPDF.sh
@@ -163,7 +163,7 @@ tesstooold=$(echo "`echo $tessversion | sed s/[.]//2`-`echo $reqtessversion | se
 
 # ensure the right GNU parallel version is installed
 # older version do not support -q flag (required to escape special characters)
-reqparallelversion="20130222"
+reqparallelversion="20121122"
 parallelversion=`parallel --minversion 0`
 ! parallel --minversion "$reqparallelversion" > /dev/null \
 	&& echo "Please install GNU parallel ${reqparallelversion} or newer (currently installed version is ${parallelversion})" && exit $EXIT_MISSING_DEPENDENCY


### PR DESCRIPTION
I added a resolution of the script's real path using "readlink -f" to find its actual location even if called via symlink (e.g. in "~/bin/OCRmyPDF").

Further the minimal required "parallel" version was set to "20130222" for the use of the quote parameter "-q". On Ubuntu 12.04 I have version "20121122" which has the "-q" parameter and works just fine, so I lowered the version requirement.
